### PR TITLE
Update schema after migrating to v7.5.0 of openapiGenerator

### DIFF
--- a/openapi/v1/schemas/expression/ExpressionItem.yaml
+++ b/openapi/v1/schemas/expression/ExpressionItem.yaml
@@ -37,16 +37,13 @@ properties:
   value:
     example:
       expression: 1.82
-    anyOf:
-    - type: object
-      patternProperties:
-        "^.*$":
-          format: double
-          type:
-            - number
-            - string
-    - type: "null"
     type: object
+    patternProperties:
+      "^.*$":
+        format: double
+        oneOf:
+        - type: number
+        - type: string # Inf or -Inf
   description:
     type: string
     readOnly: true


### PR DESCRIPTION
We had complete tests failed after https://github.com/genestack/openapi/pull/147 was merged, a `value` field with `null` value appeared in python code. So I've changed the schema.