### PR TITLE
Description updated to notify the existing limitation

### DIFF
--- a/buildSrc/.kotlin/errors/errors-1748595922820.log
+++ b/buildSrc/.kotlin/errors/errors-1748595922820.log
@@ -1,0 +1,4 @@
+kotlin version: 2.0.21
+error message: The daemon has terminated unexpectedly on startup attempt #1 with error code: 0. The daemon process output:
+    1. Kotlin compile daemon is ready
+

--- a/buildSrc/.kotlin/errors/errors-1748595922820.log
+++ b/buildSrc/.kotlin/errors/errors-1748595922820.log
@@ -1,4 +1,0 @@
-kotlin version: 2.0.21
-error message: The daemon has terminated unexpectedly on startup attempt #1 with error code: 0. The daemon process output:
-    1. Kotlin compile daemon is ready
-

--- a/openapi/v1/odmApi.yaml
+++ b/openapi/v1/odmApi.yaml
@@ -18026,6 +18026,9 @@ paths:
     post:
       operationId: "create"
       requestBody:
+        description: "Request body for creating a new xrefset.\n## Important:\nThe\
+          \ length of 'sourceId' strings is limited to 255 characters. Ensure that\
+          \ the provided values adhere to this limitation to avoid data truncation.\n"
         content:
           application/json:
             schema:
@@ -18073,7 +18076,9 @@ paths:
         targetId\" and \"sourceId\". If non-empty lists of values for \"targetId\"\
         \ and \"sourceId\" are supplied, the following search rule is applied: (sourceId\
         \ = \"S1\" OR .. sourceId = \"Sn\") AND (targetId = \"T1\" OR .. targetId\
-        \ = \"Tm\").\n\n"
+        \ = \"Tm\").\n## Important:\nThe length of 'sourceId' strings is limited to\
+        \ 255 characters. Ensure that the provided values adhere to this limitation\
+        \ to avoid data truncation.\n"
       operationId: "searchEntries"
       parameters:
       - description: "Supply sourceId in the format \"sourceId\". For transcript-gene\

--- a/openapi/v1/referenceData.yaml
+++ b/openapi/v1/referenceData.yaml
@@ -11,6 +11,11 @@ paths:
     post:
       operationId: create
       requestBody:
+        description: |-
+          Request body for creating a new xrefset.
+          
+          ## Important:
+          The length of 'sourceId' strings is limited to 255 characters. Ensure that the provided values adhere to this limitation to avoid data truncation.
         content:
           application/json:
             schema:
@@ -57,6 +62,8 @@ paths:
         ## Conditions
         It is possible to supply a list of values for "targetId" and "sourceId". If non-empty lists of values for "targetId" and "sourceId" are supplied, the following search rule is applied: (sourceId = "S1" OR .. sourceId = "Sn") AND (targetId = "T1" OR .. targetId = "Tm").
 
+        ## Important:
+        The length of 'sourceId' strings is limited to 255 characters. Ensure that the provided values adhere to this limitation to avoid data truncation.
       operationId: searchEntries
       parameters:
       - description: "Supply sourceId in the format \"sourceId\". For transcript-gene\

--- a/openapi/v1/referenceData.yaml
+++ b/openapi/v1/referenceData.yaml
@@ -11,9 +11,8 @@ paths:
     post:
       operationId: create
       requestBody:
-        description: |-
+        description: |+
           Request body for creating a new xrefset.
-          
           ## Important:
           The length of 'sourceId' strings is limited to 255 characters. Ensure that the provided values adhere to this limitation to avoid data truncation.
         content:
@@ -61,7 +60,6 @@ paths:
       description: |+
         ## Conditions
         It is possible to supply a list of values for "targetId" and "sourceId". If non-empty lists of values for "targetId" and "sourceId" are supplied, the following search rule is applied: (sourceId = "S1" OR .. sourceId = "Sn") AND (targetId = "T1" OR .. targetId = "Tm").
-
         ## Important:
         The length of 'sourceId' strings is limited to 255 characters. Ensure that the provided values adhere to this limitation to avoid data truncation.
       operationId: searchEntries


### PR DESCRIPTION
Info about the limitation was added both to POST and GET endpoints

## Important:
The length of 'sourceId' strings is limited to 255 characters. Ensure that the provided values adhere to this limitation to avoid data truncation.

In the swagger:
<img width="1429" alt="Screenshot 2025-06-02 at 08 58 55" src="https://github.com/user-attachments/assets/0f04bee2-1758-4d0a-a06d-710c7fceee01" />
<img width="1433" alt="Screenshot 2025-06-02 at 08 59 06" src="https://github.com/user-attachments/assets/c682d51d-2669-46f6-93ee-872dcde6b9b7" />
