### PR TITLE
Revert "[ODM-12622] Try fix-broken"

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -73,7 +73,7 @@ python-api-client:
             pypi-clean.sh
 
 r-api-client:
-    FROM r-base:4.5.1
+    FROM r-base:4.5.0
     WORKDIR /app
 
     CACHE /root/.cache
@@ -83,7 +83,7 @@ r-api-client:
     # Gcc and other stuff for R source packages building
     RUN \
         apt update && \
-        apt install -y --allow-downgrades build-essential libssl-dev libcurl4-gnutls-dev curl libcom-err2=1.47.2-1+b1 && \
+        apt install -y build-essential libssl-dev libcurl4-gnutls-dev curl && \
         Rscript requirements.R
 
     COPY +build/generated generated

--- a/Earthfile
+++ b/Earthfile
@@ -73,7 +73,7 @@ python-api-client:
             pypi-clean.sh
 
 r-api-client:
-    FROM r-base:4.5.0
+    FROM r-base:4.5.1
     WORKDIR /app
 
     CACHE /root/.cache


### PR DESCRIPTION
Reverts genestack/openapi#397

Seems like ubuntu have fixed their dependencies.