### PR TITLE
ODM-13350: mark /api/v1/tasks/publish-versions as deprecated

### DIFF
--- a/openapi/v1/tasks.yaml
+++ b/openapi/v1/tasks.yaml
@@ -9,7 +9,11 @@ tags:
 paths:
   /api/v1/tasks/publish-versions:
     post:
-      description: This endpoint publishes all information from drafts and creates
+      deprecated: true
+      description: |-
+        This endpoint is deprecated and is going to be removed in the next release version 1.64
+
+        This endpoint publishes all information from drafts and creates
         new metadata versions for each study/associated objects with unpublished changes. Only
         curators with the ACCESS_ALL_DATA permission can use this method.
       operationId: publishAllStudies


### PR DESCRIPTION
https://develop-nt2.dev.gs.team/swagger/?urls.primaryName=tasks#/Tasks%20API/publishAllStudies
<img width="2032" height="636" alt="image" src="https://github.com/user-attachments/assets/54e1c4bc-af31-4ccb-989a-be483f83db7d" />
